### PR TITLE
Fix typo in README reranking section

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ ranked_results = reranker.rerank(query, documents, pooling_method: "pooler", app
 # Or apply sigmoid activation to get scores between 0 and 1
 sigmoid_results = reranker.rerank(query, documents, pooling_method: "pooler", apply_sigmoid: true)
 
-# The pooler method is the default and is recommended for cross-encoders, as is apply_sigmod, so the above is the same as:
+# The pooler method is the default and is recommended for cross-encoders, as is apply_sigmoid, so the above is the same as:
 ranked_results = reranker.rerank(query, documents)
 
 # Results are returned as an array of hashes, sorted by relevance


### PR DESCRIPTION
## Summary
- fix `apply_sigmod` typo in document reranking instructions

## Testing
- `bundle exec rake compile`
- `bundle exec rake test` *(fails: Connection Failed invalid peer certificate)*

------
https://chatgpt.com/codex/tasks/task_e_6877c8a014e88328b43a477d159c4e84