### PR TITLE
Bump rand 0.8.5 → 0.8.6 (Dependabot: rand unsoundness, low)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1702,7 +1702,7 @@ dependencies = [
  "log",
  "native-tls",
  "num_cpus",
- "rand 0.8.5",
+ "rand 0.8.6",
  "reqwest",
  "rustls",
  "serde",
@@ -3043,9 +3043,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -3931,7 +3931,7 @@ dependencies = [
  "monostate",
  "onig",
  "paste",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rayon",
  "rayon-cond 0.3.0",
  "regex",


### PR DESCRIPTION
## Summary

Resolves the low-severity Dependabot alert **"Rand is unsound with a custom logger using `rand::rng()`"** (affects `rand >= 0.7.0, < 0.8.6`).

`rand 0.8.5` is a **transitive** dependency, pulled in via `hf-hub` and `tokenizers`:

```
rand v0.8.5
├── hf-hub v0.4.1
└── tokenizers v0.21.1
```

This is a **`Cargo.lock`-only** patch bump within the 0.8 line (`0.8.5 → 0.8.6`) — no `Cargo.toml` / direct-dependency changes. The newer 0.9.x and 0.10.x `rand` versions already present in the tree are unaffected and untouched.

## Testing

- `cargo check --features metal,accelerate` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)