### PR TITLE
Bump aws-lc-rs → 1.17.0 / aws-lc-sys → 0.41.0 (Dependabot: 4 high-severity AWS-LC alerts)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,9 +174,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.14.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b8ff6c09cd57b16da53641caa860168b88c172a5ee163b0288d3d6eea12786"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -184,11 +184,10 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.31.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e44d16778acaf6a9ec9899b92cebd65580b83f685446bf2e1f5d3d732f99dcd"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
- "bindgen 0.72.1",
  "cc",
  "cmake",
  "dunce",
@@ -264,26 +263,6 @@ dependencies = [
  "quote",
  "regex",
  "rustc-hash 1.1.0",
- "shlex",
- "syn",
-]
-
-[[package]]
-name = "bindgen"
-version = "0.72.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
-dependencies = [
- "bitflags 2.9.4",
- "cexpr",
- "clang-sys",
- "itertools 0.13.0",
- "log",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 2.1.1",
  "shlex",
  "syn",
 ]
@@ -2200,7 +2179,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3243,7 +3222,7 @@ version = "0.9.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "568068db4102230882e6d4ae8de6632e224ca75fe5970f6e026a04e91ed635d3"
 dependencies = [
- "bindgen 0.69.5",
+ "bindgen",
  "lazy_static",
  "proc-macro2",
  "quote",


### PR DESCRIPTION
## Summary

Resolves **four high-severity** Dependabot alerts in `aws-lc-sys`, a transitive dependency pulled in through `rustls`:

```
aws-lc-sys v0.31.0
└── aws-lc-rs v1.14.0
    └── rustls v0.23.31  ← hf-hub / reqwest / ureq / tokio-rustls
```

| Advisory | Patched in |
|----------|-----------|
| CRL Distribution Point Scope Check Logic Error in AWS-LC | `0.39.0` |
| AWS-LC `PKCS7_verify` Signature Validation Bypass | `0.38.0` |
| AWS-LC Timing Side-Channel in AES-CCM Tag Verification | `0.38.0` |
| AWS-LC `PKCS7_verify` Certificate Chain Validation Bypass | `0.38.0` |

## Approach

`aws-lc-rs 1.14.0` pins `aws-lc-sys` below `0.39`, so a direct `aws-lc-sys` bump won't resolve (cargo rejects it against the parent's requirement). Instead this bumps the parent:

- `aws-lc-rs` `1.14.0 → 1.17.0`
- `aws-lc-sys` `0.31.0 → 0.41.0` (≥ `0.39.0`, clears all four advisories)

`Cargo.lock`-only change — no `Cargo.toml` edits. It also drops the now-unneeded `bindgen` build dependency, since newer `aws-lc-sys` ships pre-generated bindings.

## Testing

- `cargo check --features metal,accelerate` passes. Because `aws-lc-sys`'s build script compiles the native AWS-LC C library, a green check confirms the native crypto build succeeds with the new version.

> Note: independent of #105 (rand bump) — both branch off `main` and touch only `Cargo.lock`, but they edit different lines, so they should merge without conflict in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)