### PR TITLE
Add least-privilege GITHUB_TOKEN permissions to build workflow (CodeQL)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,11 @@
 name: build
 on: pull_request
+
+# The build job only checks out code, restores/saves caches, and runs tests.
+# Grant the GITHUB_TOKEN least privilege.
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:


### PR DESCRIPTION
## Summary

Resolves the CodeQL **`actions/missing-workflow-permissions`** alert (#7) on `build.yml`.

The workflow declared no `permissions:` block, so `GITHUB_TOKEN` defaulted to the repo's broad scope. The build job only checks out code, restores/saves caches, and runs tests — nothing that writes — so it's scoped to least privilege:

```yaml
permissions:
  contents: read
```

`contents: read` is all `actions/checkout` needs; the cache actions don't use `GITHUB_TOKEN` scopes.

## Related

- The other open alert (#1, `doc.yml`) is **stale** — that workflow was deleted in `954c43c` and the file no longer exists on `main`; it's being dismissed separately, no code change needed.
- The new `release.yml` in #107 gets the same hardening (top-level `contents: read` + `contents: write` overrides on the prepare/publish jobs) in that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)