### PR TITLE
Bump rust-gem-release to 0.10.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release
 
 # ============================================================================
-# red-candle's MIGRATED release workflow — adopts scientist-labs/rust-gem-release@0.8.0.
+# red-candle's MIGRATED release workflow — adopts scientist-labs/rust-gem-release@0.10.0.
 #
 # BEFORE: this file was a 270-line, 5-job workflow that hand-rolled the
 #   source + x86_64-linux + aarch64-linux + arm64-darwin build/push/attach
@@ -60,7 +60,7 @@ jobs:
     # Normal PRs don't run the expensive full-matrix build. Tags and dispatches always
     # run; a PR runs ONLY when carrying the `dry-run-release` label.
     if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'dry-run-release') }}
-    uses: scientist-labs/rust-gem-release/.github/workflows/release.yml@0.8.0
+    uses: scientist-labs/rust-gem-release/.github/workflows/release.yml@0.10.0
     with:
       # --- name aliasing: gem-name != ext-name != gemspec basename ---
       gem-name: red-candle


### PR DESCRIPTION
Bumps red-candle's caller of the shared `scientist-labs/rust-gem-release`
reusable release workflow from `@0.8.0` to `@0.10.0`, so every consumer
tracks the latest release.

## What changed
- `.github/workflows/release.yml`: `uses: ...release.yml@0.8.0` -> `@0.10.0`
- Header comment updated to match.

Two-line diff; no behavioral change to red-candle's own caller logic. The
tag trigger, `workflow_dispatch` intent gate, `dry-run-release` PR gate, and
per-gem inputs/secrets are all unchanged.

## Dry-run
Add the `dry-run-release` label to run the full precompiled release matrix
as a `publish=false` dry-run on this PR before merge. (Not added yet.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)